### PR TITLE
getGlobalContext and default values fixes

### DIFF
--- a/src/xrm-mock-generator/context.ts
+++ b/src/xrm-mock-generator/context.ts
@@ -8,9 +8,12 @@ export default class Context {
         isGuidedHelpEnabled : false,
         isHighContrastEnabled: false,
         isRTL: false,
-        userId: "1337",
+        userId: "{00000000-0000-0000-0000-000000000000}",
         userName: "jdoe",
+        securityRoles: [],
+        securityRolePrivileges: []
       }),
+      orgUniqueName: ""
     });
     return context;
   }

--- a/src/xrm-mock/data/data.mock.ts
+++ b/src/xrm-mock/data/data.mock.ts
@@ -8,6 +8,7 @@ export class DataMock implements Xrm.Data {
     public process: Xrm.ProcessFlow.ProcessManager;
 
     constructor(entity: Xrm.Entity, process?: Xrm.ProcessFlow.ProcessManager) {
+        this.attributes = new ItemCollectionMock();
         this.entity = entity;
         this.process = process;
     }

--- a/src/xrm-mock/entity/entity.mock.ts
+++ b/src/xrm-mock/entity/entity.mock.ts
@@ -1,4 +1,5 @@
 import { ItemCollectionMock } from "../collection/itemcollection/itemcollection.mock";
+import { XrmMockGenerator } from "../../xrm-mock-generator";
 
 export class EntityMock implements Xrm.Entity {
     public id: string;
@@ -83,7 +84,7 @@ export class EntityMock implements Xrm.Entity {
     private getSaveContext(saveMode: Xrm.EntitySaveMode): Xrm.Events.SaveEventContext {
         return {
             getContext: (): Xrm.GlobalContext => {
-                throw new Error("getContext not implemented.");
+                return XrmMockGenerator.context;
             },
             getDepth: null, // implemented separately for each handler
             getEventArgs: (): Xrm.Events.SaveEventArguments => {

--- a/src/xrm-mock/globalcontext/context.mock.ts
+++ b/src/xrm-mock/globalcontext/context.mock.ts
@@ -23,10 +23,10 @@ export class ContextMock implements Xrm.GlobalContext {
         this.orgLcid = components.orgLcid;
         this.orgUniqueName = components.orgUniqueName;
         this.timeZoneOffset = components.timeZoneOffset;
-        this.userId = components.userId;
-        this.userLcid = components.userLcid;
-        this.userName = components.userName;
-        this.userRoles = components.userRoles;
+        this.userId = components.userId || components.userSettings.userId;
+        this.userLcid = components.userLcid || components.userSettings.languageId;
+        this.userName = components.userName || components.userSettings.userName;
+        this.userRoles = components.userRoles || components.userSettings.securityRoles;
         this.version = components.version;
     }
 

--- a/src/xrm-mock/utility/utility.mock.ts
+++ b/src/xrm-mock/utility/utility.mock.ts
@@ -1,3 +1,5 @@
+import { XrmMockGenerator } from "../../xrm-mock-generator/xrm-mock-generator";
+
 export class UtilityMock implements Xrm.Utility {
     public alertDialog(message: string, onCloseCallback: () => void): void {
         alert(message);
@@ -43,7 +45,7 @@ export class UtilityMock implements Xrm.Utility {
     }
 
     public getGlobalContext(): Xrm.GlobalContext {
-        throw new Error("Method not implemented.");
+        return XrmMockGenerator.context;
     }
 
     public getResourceString(webResourceName: string, key: string): string {

--- a/src/xrm-mock/window.mock.ts
+++ b/src/xrm-mock/window.mock.ts
@@ -1,5 +1,6 @@
 import { ContextMock } from "./globalcontext/context.mock";
 import { XrmStaticMock } from "./xrmstatic.mock";
+import { XrmMockGenerator } from "../xrm-mock-generator/xrm-mock-generator";
 
 export class WindowMock {
     public Xrm: XrmStaticMock;
@@ -9,6 +10,6 @@ export class WindowMock {
     }
 
     public GetGlobalContext(): Xrm.GlobalContext {
-        throw new Error("not implemented");
+        return XrmMockGenerator.context;
     }
 }

--- a/test/xrm-mock-generator/builder.test.ts
+++ b/test/xrm-mock-generator/builder.test.ts
@@ -64,7 +64,7 @@ describe("XrmMockGenerator Builder", () => {
                         isRTL: false,
                         languageId: 1033,
                         securityRoles: ["cf4cc7ce-5d51-df11-97e0-00155db232d0"],
-                        userId: "1337",
+                        userId: "{00000000-0000-0000-0000-000000000000}",
                         userName: "jdoe",
                     }),
                 version: "8.2.1.185",


### PR DESCRIPTION
Hi! Great library, I just want to fix couple of things...

* getGlobalContext -- it was already implemented we needed just to expose it.
* userId is default GUID -- changed int value to valid GUID so code that might parse it works correctly.
* initialise default user variables -- user context should be present event after `initialise` withouth arguments.
* securityRoles, securityRolePrivileges -- empty lists even by default.

Tested this changes against our work project. What do you think?