### PR TITLE
Pass eventContext to attribute onChange Handlers

### DIFF
--- a/src/xrm-mock/attributes/attribute/attribute.mock.ts
+++ b/src/xrm-mock/attributes/attribute/attribute.mock.ts
@@ -1,4 +1,5 @@
 import { findIndex } from "../../../xrm-mock-generator/helpers/array.helper";
+import { XrmMockGenerator } from "../../../xrm-mock-generator/xrm-mock-generator";
 import { ItemCollectionMock } from "../../collection/itemcollection/itemcollection.mock";
 import { ControlMock } from "../../controls/control/control.mock";
 
@@ -36,7 +37,7 @@ export class AttributeMock<TControl extends ControlMock,
     public fireOnChange(): void {
         if (this.eventHandlers.length) {
             for (const handler of this.eventHandlers) {
-                handler.call(this);
+                handler.call(this, XrmMockGenerator.getEventContext());
             }
         }
     }

--- a/test/data/data.mock.test.ts
+++ b/test/data/data.mock.test.ts
@@ -1,8 +1,11 @@
-import { AttributeMock } from "../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { ItemCollectionMock } from "../../src/xrm-mock/collection/itemcollection/itemcollection.mock";
-import { DataMock } from "../../src/xrm-mock/data/data.mock";
-import { EntityMock } from "../../src/xrm-mock/entity/entity.mock";
-import { ControlMock } from "../../src/xrm-mock";
+import {
+    AttributeMock,
+    ControlMock,
+    DataMock,
+    EntityMock,
+    ItemCollectionMock
+} from "../../src/xrm-mock";
+
 
 describe("Xrm.Data Mock", () => {
     const id = "{B05EC7CE-5D51-DF11-97E0-00155DB232D0}";

--- a/test/formcontext/formcontext.mock.test.ts
+++ b/test/formcontext/formcontext.mock.test.ts
@@ -1,17 +1,14 @@
-import { AttributeMock } from "../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { StringAttributeMock } from "../../src/xrm-mock/attributes/stringattribute/stringattribute.mock";
-import { ItemCollectionMock } from "../../src/xrm-mock/collection/itemcollection/itemcollection.mock";
-import { AutoLookupControlMock } from "../../src/xrm-mock/controls/autolookupcontrol/autolookupcontrol.mock";
-import { ControlMock } from "../../src/xrm-mock/controls/control/control.mock";
-import { StandardControlMock } from "../../src/xrm-mock/controls/standardcontrol/standardcontrol.mock";
-import { StringControlMock } from "../../src/xrm-mock/controls/stringcontrol/stringcontrol.mock";
-import { UiKeyPressableMock } from "../../src/xrm-mock/controls/uikeypressable/uikeypressable.mock";
-import { DataMock } from "../../src/xrm-mock/data/data.mock";
-import { EntityMock } from "../../src/xrm-mock/entity/entity.mock";
-import { FormContextMock } from "../../src/xrm-mock/formcontext/formcontext.mock";
-import { PageMock } from "../../src/xrm-mock/page/page.mock";
-import { UiMock } from "../../src/xrm-mock/ui/ui.mock";
-import { XrmStaticMock } from "../../src/xrm-mock/xrmstatic.mock";
+import {
+    AttributeMock,
+    DataMock,
+    EntityMock,
+    FormContextMock,
+    ItemCollectionMock,
+    StringAttributeMock,
+    StringControlMock,
+    UiMock
+} from "../../src/xrm-mock";
+
 
 describe("FormContext Mock", () => {
     let lastName: StringAttributeMock;
@@ -45,11 +42,11 @@ describe("FormContext Mock", () => {
 
         formContext = new FormContextMock(
             new DataMock(
-                new EntityMock({ attributes: new ItemCollectionMock<AttributeMock<StringControlMock, string>>(attributes)})),
-                new UiMock({
-                    controls: new ItemCollectionMock<StringControlMock>(controls),
-                },
-        ));
+            new EntityMock({ attributes: new ItemCollectionMock<AttributeMock<StringControlMock, string>>(attributes)})),
+            new UiMock({
+                controls: new ItemCollectionMock<StringControlMock>(controls),
+            },
+            ));
     });
 
     it("should exist", () => {

--- a/test/page/attribute/attribute.mock.test.ts
+++ b/test/page/attribute/attribute.mock.test.ts
@@ -1,5 +1,4 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { ControlMock } from "../../../src/xrm-mock";
+import { AttributeMock, ControlMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.Attribute Mock", () => {
     let attributeMock: AttributeMock<ControlMock, string>;

--- a/test/page/booleanattribute/booleanattribute.mock.test.ts
+++ b/test/page/booleanattribute/booleanattribute.mock.test.ts
@@ -1,6 +1,4 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { BooleanAttributeMock } from "../../../src/xrm-mock/attributes/booleanattribute/booleanattribute.mock";
-import { EnumAttributeMock } from "../../../src/xrm-mock/attributes/enumattribute/enumattribute.mock";
+import { AttributeMock, BooleanAttributeMock, EnumAttributeMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.BooleanAttribute Mock", () => {
     let booleanAttribute: BooleanAttributeMock;

--- a/test/page/booleancontrol/booleancontrol.mock.test.ts
+++ b/test/page/booleancontrol/booleancontrol.mock.test.ts
@@ -1,7 +1,4 @@
-import {
-    BooleanAttributeMock,
-    IBooleanAttributeComponents
-} from "../../../src/xrm-mock/attributes/booleanattribute/booleanattribute.mock";
+import { BooleanAttributeMock, IBooleanAttributeComponents } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.BooleanAttribute Mock", () => {
     const attribute: IBooleanAttributeComponents = {

--- a/test/page/dateattribute/dateattribute.mock.test.ts
+++ b/test/page/dateattribute/dateattribute.mock.test.ts
@@ -1,14 +1,13 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { DateAttributeMock } from "../../../src/xrm-mock/attributes/dateattribute/dateattribute.mock";
+import { DateAttributeMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.DateAttribute Mock", () => {
     let dateAttribute: DateAttributeMock;
     beforeEach(() => {
         dateAttribute = new DateAttributeMock({
-                format: "date",
-                isDirty: false,
-                name: "birthdate",
-                value: new Date("January 1, 1990"),
+            format: "date",
+            isDirty: false,
+            name: "birthdate",
+            value: new Date("January 1, 1990"),
         });
     });
 

--- a/test/page/datecontrol/datecontrol.mock.test.ts
+++ b/test/page/datecontrol/datecontrol.mock.test.ts
@@ -1,5 +1,4 @@
-import { DateAttributeMock } from "../../../src/xrm-mock/attributes/dateattribute/dateattribute.mock";
-import { DateControlMock } from "../../../src/xrm-mock/controls/datecontrol/datecontrol.mock";
+import { DateAttributeMock, DateControlMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Controls.DateControl Mock", () => {
     let control: DateControlMock;

--- a/test/page/entity/entity.mock.test.ts
+++ b/test/page/entity/entity.mock.test.ts
@@ -1,10 +1,12 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { ItemCollectionMock } from "../../../src/xrm-mock/collection/itemcollection/itemcollection.mock";
-import { DataMock } from "../../../src/xrm-mock/data/data.mock";
-import { EntityMock } from "../../../src/xrm-mock/entity/entity.mock";
-import { FormContextMock } from "../../../src/xrm-mock/formcontext/formcontext.mock";
-import { PageMock } from "../../../src/xrm-mock/page/page.mock";
-import { ControlMock } from "../../../src/xrm-mock";
+import {
+    AttributeMock,
+    ControlMock,
+    DataMock,
+    EntityMock,
+    FormContextMock,
+    ItemCollectionMock,
+    PageMock
+} from "../../../src/xrm-mock";
 
 describe("Xrm.Entity Mock", () => {
     const id = "{0}";

--- a/test/page/enumattribute/enumattribute.mock.test.ts
+++ b/test/page/enumattribute/enumattribute.mock.test.ts
@@ -1,5 +1,4 @@
-import { EnumAttributeMock } from "../../../src/xrm-mock/attributes/enumattribute/enumattribute.mock";
-import { ControlMock } from "../../../src/xrm-mock";
+import { ControlMock, EnumAttributeMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.EnumAttribute Mock", () => {
     let enumAttribute: EnumAttributeMock<ControlMock, boolean>;

--- a/test/page/lookupattribute/lookupattribute.mock.test.ts
+++ b/test/page/lookupattribute/lookupattribute.mock.test.ts
@@ -1,6 +1,4 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { LookupAttributeMock} from "../../../src/xrm-mock/attributes/lookupattribute/lookupattribute.mock";
-import { LookupValueMock } from "../../../src/xrm-mock/lookupvalue/lookupvalue.mock";
+import { LookupAttributeMock, LookupValueMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.LookupAttribute Mock", () => {
     let lookupAttribute: LookupAttributeMock;

--- a/test/page/numberattribute/numberattribute.mock.test.ts
+++ b/test/page/numberattribute/numberattribute.mock.test.ts
@@ -1,5 +1,4 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { NumberAttributeMock } from "../../../src/xrm-mock/attributes/numberattribute/numberattribute.mock";
+import { NumberAttributeMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.NumberAttribute", () => {
     let numberAttribute: NumberAttributeMock;
@@ -91,5 +90,5 @@ describe("Xrm.Attributes.NumberAttribute", () => {
             .toThrowError("precision cannot be less than 0, but was -1");
         expect(() => { const a = new NumberAttributeMock({name: "", precision: 11}); })
             .toThrowError("precision cannot be greater than 10, but was 11");
-});
+    });
 });

--- a/test/page/optionsetattribute/optionsetattribute.mock.test.ts
+++ b/test/page/optionsetattribute/optionsetattribute.mock.test.ts
@@ -1,6 +1,4 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { OptionSetAttributeMock } from "../../../src/xrm-mock/attributes/optionsetattribute/optionsetattribute.mock";
-import { OptionSetValueMock } from "../../../src/xrm-mock/optionsetvalue/optionsetvalue.mock";
+import { OptionSetAttributeMock, OptionSetValueMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.OptionSetAttribute Mock", () => {
     let optionSetAttribute: OptionSetAttributeMock;

--- a/test/page/optionsetcontrol/optionsetcontrol.mock.test.ts
+++ b/test/page/optionsetcontrol/optionsetcontrol.mock.test.ts
@@ -1,6 +1,8 @@
-import { OptionSetAttributeMock } from "../../../src/xrm-mock/attributes/optionsetattribute/optionsetattribute.mock";
-import { OptionSetControlMock } from "../../../src/xrm-mock/controls/optionsetcontrol/optionsetcontrol.mock";
-import { OptionSetValueMock } from "../../../src/xrm-mock/optionsetvalue/optionsetvalue.mock";
+import {
+    OptionSetAttributeMock,
+    OptionSetControlMock,
+    OptionSetValueMock
+} from "../../../src/xrm-mock";
 
 describe("Xrm.Controls.OptionSetControl Mock", () => {
     let control: OptionSetControlMock;

--- a/test/page/page.mock.test.ts
+++ b/test/page/page.mock.test.ts
@@ -1,17 +1,15 @@
-import { AttributeMock } from "../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { StringAttributeMock } from "../../src/xrm-mock/attributes/stringattribute/stringattribute.mock";
-import { ItemCollectionMock } from "../../src/xrm-mock/collection/itemcollection/itemcollection.mock";
-import { AutoLookupControlMock } from "../../src/xrm-mock/controls/autolookupcontrol/autolookupcontrol.mock";
-import { ControlMock } from "../../src/xrm-mock/controls/control/control.mock";
-import { StandardControlMock } from "../../src/xrm-mock/controls/standardcontrol/standardcontrol.mock";
-import { StringControlMock } from "../../src/xrm-mock/controls/stringcontrol/stringcontrol.mock";
-import { UiKeyPressableMock } from "../../src/xrm-mock/controls/uikeypressable/uikeypressable.mock";
-import { DataMock } from "../../src/xrm-mock/data/data.mock";
-import { EntityMock } from "../../src/xrm-mock/entity/entity.mock";
-import { FormContextMock } from "../../src/xrm-mock/formcontext/formcontext.mock";
-import { PageMock } from "../../src/xrm-mock/page/page.mock";
-import { UiMock } from "../../src/xrm-mock/ui/ui.mock";
-import { XrmStaticMock } from "../../src/xrm-mock/xrmstatic.mock";
+import {
+    AttributeMock,
+    DataMock,
+    EntityMock,
+    FormContextMock,
+    ItemCollectionMock,
+    PageMock,
+    StringAttributeMock,
+    StringControlMock,
+    UiMock
+} from "../../src/xrm-mock";
+
 
 describe("Xrm.Page Mock", () => {
     let lastName: StringAttributeMock;
@@ -46,11 +44,11 @@ describe("Xrm.Page Mock", () => {
 
         formContext = new FormContextMock(
             new DataMock(
-                new EntityMock({ attributes: new ItemCollectionMock<AttributeMock<StringControlMock, string>>(attributes)})),
-                new UiMock({
-                    controls: new ItemCollectionMock<StringControlMock>(controls),
-                },
-        ));
+            new EntityMock({ attributes: new ItemCollectionMock<AttributeMock<StringControlMock, string>>(attributes)})),
+            new UiMock({
+                controls: new ItemCollectionMock<StringControlMock>(controls),
+            },
+            ));
         xrmPageMock = new PageMock(null, formContext);
     });
 

--- a/test/page/standardcontrol/standardcontrol.mock.test.ts
+++ b/test/page/standardcontrol/standardcontrol.mock.test.ts
@@ -1,5 +1,4 @@
-import { AttributeMock } from "../../../src/xrm-mock/attributes/attribute/attribute.mock";
-import { StandardControlMock } from "../../../src/xrm-mock/controls/standardcontrol/standardcontrol.mock";
+import { AttributeMock, StandardControlMock } from "../../../src/xrm-mock";
 
 describe("Xrm.Controls.StandardControl Mock", () => {
   let standardControl: StandardControlMock<any, any, any>;

--- a/test/page/stringattribute/stringattribute.mock.test.ts
+++ b/test/page/stringattribute/stringattribute.mock.test.ts
@@ -1,7 +1,7 @@
 import {
     IStringAttributeComponents,
     StringAttributeMock
-} from "../../../src/xrm-mock/attributes/stringattribute/stringattribute.mock";
+} from "../../../src/xrm-mock";
 
 describe("Xrm.Attributes.StringAttribute Mock", () => {
     const attribute: IStringAttributeComponents = {

--- a/test/xrm-mock-generator/builder.test.ts
+++ b/test/xrm-mock-generator/builder.test.ts
@@ -1,6 +1,21 @@
 import * as sinon from "sinon";
-import { AttributeMock, ClientContextMock, ContextMock, EntityMock, EventContextMock, FormItemMock, FormSelectorMock, IAttributeComponents, IEntityComponents, IGridControlComponents, IStringControlComponents, ItemCollectionMock, IUiComponents, NavigationStaticMock, ProcessManagerMock, ProcessMock, StageMock, StepMock, StringAttributeMock, StringControlMock, UiMock, UserSettingsMock } from "../../src/xrm-mock";
-import { IXrmGeneratorComponents, XrmMockGenerator } from "../../src/xrm-mock-generator";
+import {
+    ClientContextMock,
+    ContextMock,
+    EntityMock,
+    EventContextMock,
+    FormItemMock,
+    FormSelectorMock,
+    ItemCollectionMock,
+    ProcessManagerMock,
+    ProcessMock,
+    StageMock,
+    StepMock,
+    StringAttributeMock,
+    UiMock,
+    UserSettingsMock
+} from "../../src/xrm-mock";
+import { XrmMockGenerator } from "../../src/xrm-mock-generator";
 import FormContext from "../../src/xrm-mock-generator/formcontext";
 
 describe("XrmMockGenerator Builder", () => {
@@ -21,28 +36,28 @@ describe("XrmMockGenerator Builder", () => {
     beforeAll(() => {
         // attributes
         const nameAttribute = new StringAttributeMock({
-                name: "name",
-                requiredLevel: "required",
-            });
+            name: "name",
+            requiredLevel: "required",
+        });
         nameAttribute.addOnChange(() => tempValue = "Test OnChange!");
         // entity
         const entity = new EntityMock({
-                attributes: new ItemCollectionMock<Xrm.Attributes.Attribute>([nameAttribute]),
-                entityName: "account",
-                id: "{00000000-0000-0000-0000-000000000000}",
-            });
+            attributes: new ItemCollectionMock<Xrm.Attributes.Attribute>([nameAttribute]),
+            entityName: "account",
+            id: "{00000000-0000-0000-0000-000000000000}",
+        });
         // ui
         const ui = new UiMock({
-                formSelector: new FormSelectorMock(new ItemCollectionMock<FormItemMock>(
-                    [
-                        new FormItemMock({
-                            currentItem: true,
-                            formType: 2,
-                            id: "5",
-                            label: "Main",
-                        }),
-                    ])),
-            });
+            formSelector: new FormSelectorMock(new ItemCollectionMock<FormItemMock>(
+                [
+                    new FormItemMock({
+                        currentItem: true,
+                        formType: 2,
+                        id: "5",
+                        label: "Main",
+                    }),
+                ])),
+        });
         // context
         const globalContext = new ContextMock(
             {
@@ -91,11 +106,11 @@ describe("XrmMockGenerator Builder", () => {
         const processManager = new ProcessManagerMock([process1, process2]);
 
         XrmMockGenerator.initialise({
-                context: globalContext,
-                entity,
-                process: processManager,
-                ui,
-            });
+            context: globalContext,
+            entity,
+            process: processManager,
+            ui,
+        });
 
         // form structure
         XrmMockGenerator.Tab.createTab("testTab", "Test Tab", false, "collapsed", null,
@@ -262,6 +277,13 @@ describe("XrmMockGenerator Builder", () => {
             tempValue = "";
             attribute.fireOnChange();
             expect(tempValue).toBe("Test OnChange!");
+        });
+
+        it("should fire OnChange with eventContext", () => {
+            const onChangeEventMock = jest.fn();
+            attribute.addOnChange(onChangeEventMock);
+            attribute.fireOnChange();
+            expect(onChangeEventMock).toBeCalledWith(XrmMockGenerator.getEventContext());
         });
     });
 


### PR DESCRIPTION
Fixes #44 

This test will now pass:
```typescript
it("should fire OnChange with eventContext", () => {
    const onChangeEventMock = jest.fn();
    attribute.addOnChange(onChangeEventMock);
    attribute.fireOnChange();
    expect(onChangeEventMock).toBeCalledWith(XrmMockGenerator.getEventContext());
});
```
See https://github.com/scottdurow/xrm-mock/blob/0ccb168c5d19d712a0ea16a7c43e4b1e4e5fbfc7/test/xrm-mock-generator/builder.test.ts#L282

Note: Now that `XrmMockGenerator` is imported into `attribute.mock.ts` - there was an import order issue with the tests - so I've refactored the imports on the tests that were failing.